### PR TITLE
simplified Print method to 1 line

### DIFF
--- a/src/HashmapTest.java
+++ b/src/HashmapTest.java
@@ -246,10 +246,7 @@ public class HashmapTest {
 
     static void PrintCurrentHashMap()
     {
-        if(CurrentInput.equalsIgnoreCase(inputPrint))
-        {
-            System.out.println("current hashmap of " + hashmapName + " has the values " + Hashinteract.HashMapGet());
-        }
+        System.out.println("current hashmap " + hashmapName + " has the values " + Hashinteract.HashMapGet());
     }
 
     static void ContainsKeyHashMap()


### PR DESCRIPTION
simplified PrintCurrentHashMap() down to 1 line, removing the redundant line where the print method checks if CurrentInput = "pr". This is already handled by the switch statement at the top